### PR TITLE
Remove lodash isplainobject

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,12 @@ Logs are organized according to [Keep a Changelog](https://keepachangelog.com/en
 
 ### Security
 
+## [1.1.0] - 2024-01-07
+
+### Changed
+
+- Removed dependency on `lodash.isplainobject` in favour of custom utility
+
 ## [1.0.0] - 2023-12-07
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
   "license": "MIT",
   "dependencies": {
     "lodash.camelcase": "4",
-    "lodash.isplainobject": "4",
     "lodash.kebabcase": "4",
     "lodash.snakecase": "4",
     "ts-loader": "9.5",
@@ -24,7 +23,6 @@
   "devDependencies": {
     "@types/jest": "29",
     "@types/lodash.camelcase": "4",
-    "@types/lodash.isplainobject": "4",
     "@types/lodash.kebabcase": "4",
     "@types/lodash.snakecase": "4",
     "jest": "29",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jerridan/convert-keys",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "A tool for converting object keys between camel case, snake case and kebab case.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
     "lodash.camelcase": "4",
     "lodash.kebabcase": "4",
     "lodash.snakecase": "4",
-    "ts-loader": "9.5",
     "typescript": "5.3"
   },
   "devDependencies": {
@@ -29,6 +28,7 @@
     "prettier": "3",
     "rimraf": "5",
     "ts-jest": "29",
+    "ts-loader": "9.5",
     "ts-node": "10",
     "webpack": "5.89",
     "webpack-bundle-analyzer": "^4.10.1",

--- a/src/convertStructure.ts
+++ b/src/convertStructure.ts
@@ -1,4 +1,4 @@
-import isPlainObject from "lodash.isplainobject";
+import { isPlainObject } from "./utils/isPlainObject";
 import { Overrides, PlainObject, PlainArray } from "./types";
 
 export function convertStructure(

--- a/src/toCamelCase.ts
+++ b/src/toCamelCase.ts
@@ -1,5 +1,5 @@
 import { Overrides, PlainObject, PlainArray } from "./types";
-import ConvertKey from "./ConvertKey";
+import ConvertKey from "./utils/ConvertKey";
 import { convertStructure } from "./convertStructure";
 
 export function toCamelCase(

--- a/src/toKebabCase.ts
+++ b/src/toKebabCase.ts
@@ -1,5 +1,5 @@
 import { Overrides, PlainObject, PlainArray } from "./types";
-import ConvertKey from "./ConvertKey";
+import ConvertKey from "./utils/ConvertKey";
 import { convertStructure } from "./convertStructure";
 
 export function toKebabCase(

--- a/src/toSnakeCase.ts
+++ b/src/toSnakeCase.ts
@@ -1,5 +1,5 @@
 import { Overrides, PlainObject, PlainArray } from "./types";
-import ConvertKey from "./ConvertKey";
+import ConvertKey from "./utils/ConvertKey";
 import { convertStructure } from "./convertStructure";
 
 export function toSnakeCase(

--- a/src/utils/ConvertKey.ts
+++ b/src/utils/ConvertKey.ts
@@ -1,7 +1,7 @@
 import lodashCamelCase from "lodash.camelcase";
 import lodashKebabCase from "lodash.kebabcase";
 import lodashSnakeCase from "lodash.snakecase";
-import { Overrides } from "./types";
+import { Overrides } from "../types";
 
 function camelCase(key: string, overrides?: Overrides): string {
   if (overrides && overrides[key]) {

--- a/src/utils/isPlainObject.spec.ts
+++ b/src/utils/isPlainObject.spec.ts
@@ -14,4 +14,14 @@ describe("isPlainObject", () => {
     expect(isPlainObject([])).toBe(false);
     expect(isPlainObject([1, 2])).toBe(false);
   });
+
+  it("returns false for functions", () => {
+    expect(isPlainObject(() => {})).toBe(false);
+  });
+
+  it("returns false for primitives", () => {
+    expect(isPlainObject("string")).toBe(false);
+    expect(isPlainObject(1)).toBe(false);
+    expect(isPlainObject(true)).toBe(false);
+  });
 });

--- a/src/utils/isPlainObject.spec.ts
+++ b/src/utils/isPlainObject.spec.ts
@@ -24,4 +24,12 @@ describe("isPlainObject", () => {
     expect(isPlainObject(1)).toBe(false);
     expect(isPlainObject(true)).toBe(false);
   });
+
+  it("returns false for null", () => {
+    expect(isPlainObject(null)).toBe(false);
+  });
+
+  it("returns false for undefined", () => {
+    expect(isPlainObject(undefined)).toBe(false);
+  });
 });

--- a/src/utils/isPlainObject.spec.ts
+++ b/src/utils/isPlainObject.spec.ts
@@ -40,4 +40,11 @@ describe("isPlainObject", () => {
   it("returns false for undefined", () => {
     expect(isPlainObject(undefined)).toEqual(false);
   });
+
+  it("returns false for classes and class instances", () => {
+    class Test {}
+
+    expect(isPlainObject(Test)).toEqual(false);
+    expect(isPlainObject(new Test())).toEqual(false);
+  });
 });

--- a/src/utils/isPlainObject.spec.ts
+++ b/src/utils/isPlainObject.spec.ts
@@ -1,0 +1,17 @@
+import { isPlainObject } from "./isPlainObject";
+
+describe("isPlainObject", () => {
+  it("returns true for plain objects", () => {
+    expect(isPlainObject({})).toBe(true);
+    expect(isPlainObject({ a: 1 })).toBe(true);
+  });
+
+  it("returns true when the constructor property has been changed", () => {
+    expect(isPlainObject({ constructor: 1 })).toBe(true);
+  });
+
+  it("returns false for arrays", () => {
+    expect(isPlainObject([])).toBe(false);
+    expect(isPlainObject([1, 2])).toBe(false);
+  });
+});

--- a/src/utils/isPlainObject.spec.ts
+++ b/src/utils/isPlainObject.spec.ts
@@ -2,42 +2,42 @@ import { isPlainObject } from "./isPlainObject";
 
 describe("isPlainObject", () => {
   it("returns true for plain objects", () => {
-    expect(isPlainObject({})).toBe(true);
-    expect(isPlainObject({ a: 1 })).toBe(true);
+    expect(isPlainObject({})).toEqual(true);
+    expect(isPlainObject({ a: 1 })).toEqual(true);
   });
 
   it("returns true when the constructor property has been changed", () => {
-    expect(isPlainObject({ constructor: 1 })).toBe(true);
+    expect(isPlainObject({ constructor: 1 })).toEqual(true);
   });
 
   it("returns false for objects with a prototype", () => {
-    expect(isPlainObject(Object.create({ a: 1 }))).toBe(false);
+    expect(isPlainObject(Object.create({ a: 1 }))).toEqual(false);
   });
 
   it("returns true for objects with a valueOf method", () => {
-    expect(isPlainObject({ valueOf: 0 })).toBe(true);
+    expect(isPlainObject({ valueOf: 0 })).toEqual(true);
   });
 
   it("returns false for arrays", () => {
-    expect(isPlainObject([])).toBe(false);
-    expect(isPlainObject([1, 2])).toBe(false);
+    expect(isPlainObject([])).toEqual(false);
+    expect(isPlainObject([1, 2])).toEqual(false);
   });
 
   it("returns false for functions", () => {
-    expect(isPlainObject(() => {})).toBe(false);
+    expect(isPlainObject(() => {})).toEqual(false);
   });
 
   it("returns false for primitives", () => {
-    expect(isPlainObject("string")).toBe(false);
-    expect(isPlainObject(1)).toBe(false);
-    expect(isPlainObject(true)).toBe(false);
+    expect(isPlainObject("string")).toEqual(false);
+    expect(isPlainObject(1)).toEqual(false);
+    expect(isPlainObject(true)).toEqual(false);
   });
 
   it("returns false for null", () => {
-    expect(isPlainObject(null)).toBe(false);
+    expect(isPlainObject(null)).toEqual(false);
   });
 
   it("returns false for undefined", () => {
-    expect(isPlainObject(undefined)).toBe(false);
+    expect(isPlainObject(undefined)).toEqual(false);
   });
 });

--- a/src/utils/isPlainObject.spec.ts
+++ b/src/utils/isPlainObject.spec.ts
@@ -10,6 +10,10 @@ describe("isPlainObject", () => {
     expect(isPlainObject({ constructor: 1 })).toBe(true);
   });
 
+  it("returns false for objects with a prototype", () => {
+    expect(isPlainObject(Object.create({ a: 1 }))).toBe(false);
+  });
+
   it("returns false for arrays", () => {
     expect(isPlainObject([])).toBe(false);
     expect(isPlainObject([1, 2])).toBe(false);

--- a/src/utils/isPlainObject.spec.ts
+++ b/src/utils/isPlainObject.spec.ts
@@ -14,6 +14,10 @@ describe("isPlainObject", () => {
     expect(isPlainObject(Object.create({ a: 1 }))).toBe(false);
   });
 
+  it("returns true for objects with a valueOf method", () => {
+    expect(isPlainObject({ valueOf: 0 })).toBe(true);
+  });
+
   it("returns false for arrays", () => {
     expect(isPlainObject([])).toBe(false);
     expect(isPlainObject([1, 2])).toBe(false);

--- a/src/utils/isPlainObject.spec.ts
+++ b/src/utils/isPlainObject.spec.ts
@@ -47,4 +47,8 @@ describe("isPlainObject", () => {
     expect(isPlainObject(Test)).toEqual(false);
     expect(isPlainObject(new Test())).toEqual(false);
   });
+
+  it("returns false for errors", () => {
+    expect(isPlainObject(new Error())).toEqual(false);
+  });
 });

--- a/src/utils/isPlainObject.spec.ts
+++ b/src/utils/isPlainObject.spec.ts
@@ -10,8 +10,12 @@ describe("isPlainObject", () => {
     expect(isPlainObject({ constructor: 1 })).toEqual(true);
   });
 
-  it("returns false for objects with a prototype", () => {
+  it("returns false for objects with a custom prototype", () => {
     expect(isPlainObject(Object.create({ a: 1 }))).toEqual(false);
+  });
+
+  it("returns true for objects with a null prototype", () => {
+    expect(isPlainObject(Object.create(null))).toEqual(true);
   });
 
   it("returns true for objects with a valueOf method", () => {

--- a/src/utils/isPlainObject.ts
+++ b/src/utils/isPlainObject.ts
@@ -1,4 +1,5 @@
 export function isPlainObject(value: any) {
+  if (!value) return false;
+
   return Object.getPrototypeOf(value) === Object.prototype;
-  // return value.constructor === Object;
 }

--- a/src/utils/isPlainObject.ts
+++ b/src/utils/isPlainObject.ts
@@ -1,0 +1,4 @@
+export function isPlainObject(value: any) {
+  return Object.getPrototypeOf(value) === Object.prototype;
+  // return value.constructor === Object;
+}

--- a/src/utils/isPlainObject.ts
+++ b/src/utils/isPlainObject.ts
@@ -1,5 +1,5 @@
 export function isPlainObject(value: any) {
   if (!value) return false;
 
-  return Object.getPrototypeOf(value) === Object.prototype;
+  return [null, Object.prototype].includes(Object.getPrototypeOf(value));
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -769,13 +769,6 @@
   dependencies:
     "@types/lodash" "*"
 
-"@types/lodash.isplainobject@4":
-  version "4.0.9"
-  resolved "https://registry.yarnpkg.com/@types/lodash.isplainobject/-/lodash.isplainobject-4.0.9.tgz#3e0159c1598d96af2372151ed65f2792b61787e4"
-  integrity sha512-QC8nKcap5hRrbtIaPRjUMlcXXnLeayqQZPSaWJDx3xeuN17+2PW5wkmEJ4+lZgNnQRlSPzxjTYKCfV1uTnPaEg==
-  dependencies:
-    "@types/lodash" "*"
-
 "@types/lodash.kebabcase@4":
   version "4.1.9"
   resolved "https://registry.yarnpkg.com/@types/lodash.kebabcase/-/lodash.kebabcase-4.1.9.tgz#48d3df753b89499e75eba5e017979b560d69df85"
@@ -2366,11 +2359,6 @@ lodash.camelcase@4:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz#b28aa6288a2b9fc651035c7711f65ab6190331a6"
   integrity sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==
-
-lodash.isplainobject@4:
-  version "4.0.6"
-  resolved "https://registry.yarnpkg.com/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz#7c526a52d89b45c45cc690b88163be0497f550cb"
-  integrity sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==
 
 lodash.kebabcase@4:
   version "4.1.1"


### PR DESCRIPTION
**What was done**
The dependency on `lodash.isplainobject` has been replaced by a new utility

**Why this is important**
Lodash dependencies account for a large portion of the current bundle size. The goal is to eventually replace each of the lodash deps to make `convertKeys` a more lightweight tool.